### PR TITLE
Add count function

### DIFF
--- a/c_src/eleveldb.h
+++ b/c_src/eleveldb.h
@@ -51,6 +51,8 @@ ERL_NIF_TERM async_iterator(ErlNifEnv* env, int argc, const ERL_NIF_TERM argv[])
 ERL_NIF_TERM async_iterator_move(ErlNifEnv* env, int argc, const ERL_NIF_TERM argv[]);
 ERL_NIF_TERM async_iterator_close(ErlNifEnv* env, int argc, const ERL_NIF_TERM argv[]);
 
+ERL_NIF_TERM async_count(ErlNifEnv* env, int argc, const ERL_NIF_TERM argv[]);
+
 } // namespace eleveldb
 
 

--- a/c_src/workitems.cc
+++ b/c_src/workitems.cc
@@ -592,6 +592,36 @@ DestroyTask::DoWork()
 
 }   // DestroyTask::DoWork()
 
+/**
+ * CountTask functions
+ */
+
+CountTask::CountTask(ErlNifEnv *_caller_env,
+                 ERL_NIF_TERM _caller_ref,
+                 DbObjectPtr_t & _db_handle)
+    : WorkTask(_caller_env, _caller_ref, _db_handle)
+{}
+
+CountTask::~CountTask() {}
+
+work_result
+CountTask::DoWork()
+{
+
+    uint64_t cnt = 0;
+
+    leveldb::Iterator* it = m_DbPtr->m_Db->NewIterator(leveldb::ReadOptions());
+    for (it->SeekToFirst(); it->Valid(); it->Next()) {
+        cnt++;
+    }
+    leveldb::Status status = it->status();
+    delete it;
+    if(!status.ok()){
+        return work_result(local_env(), ATOM_ERROR, status);
+    }
+
+    return work_result(local_env(), ATOM_OK, enif_make_uint64(local_env_, cnt));
+}
 
 } // namespace eleveldb
 

--- a/c_src/workitems.h
+++ b/c_src/workitems.h
@@ -336,6 +336,23 @@ private:
 
 };  // class DestroyTask
 
+/**
+ * Background object for async count,
+ */
+
+class CountTask : public WorkTask
+{
+public:
+    CountTask(ErlNifEnv *_caller_env,
+            ERL_NIF_TERM _caller_ref,
+            DbObjectPtr_t & _db_handle);
+
+    virtual ~CountTask();
+
+    virtual work_result DoWork();
+
+};  // class CountTask
+
 
 
 } // namespace eleveldb


### PR DESCRIPTION
In order to make record counting as fast as possible by reducing the number of interactions between erlang runtime and NIF for https://github.com/leo-project/leofs/issues/974.