### PR TITLE
Add first_n function

### DIFF
--- a/c_src/eleveldb.cc
+++ b/c_src/eleveldb.cc
@@ -81,6 +81,7 @@ static ErlNifFunc nif_funcs[] =
     {"async_iterator_move", 3, eleveldb::async_iterator_move},
 
     {"async_count", 2, eleveldb::async_count},
+    {"async_first_n", 3, eleveldb::async_first_n},
 
     {"property_cache", 2, eleveldb::property_cache},
     {"property_cache_get", 1, eleveldb::property_cache_get},
@@ -1061,6 +1062,36 @@ async_count(
     return submit_to_thread_queue(work_item, env, caller_ref);
 }   // async_count
 
+ERL_NIF_TERM
+async_first_n(
+    ErlNifEnv* env,
+    int argc,
+    const ERL_NIF_TERM argv[])
+{
+    const ERL_NIF_TERM& caller_ref  = argv[0];
+    const ERL_NIF_TERM& dbh_ref     = argv[1];
+    const ERL_NIF_TERM& number_of_recs_ref = argv[2];
+    unsigned long number_of_recs = 0;
+
+    ReferencePtr<DbObject> db_ptr;
+
+    db_ptr.assign(DbObject::RetrieveDbObject(env, dbh_ref));
+
+    if(NULL==db_ptr.get() || 0!=db_ptr->GetCloseRequested())
+    {
+        return enif_make_badarg(env);
+    }
+
+    // likely useless
+    if(NULL == db_ptr->m_Db)
+        return send_reply(env, caller_ref, error_einval(env));
+
+    if (enif_get_ulong(env, number_of_recs_ref, &number_of_recs) == 0)
+        return enif_make_badarg(env);
+
+    eleveldb::WorkTask *work_item = new eleveldb::FirstNTask(env, caller_ref, db_ptr, number_of_recs);
+    return submit_to_thread_queue(work_item, env, caller_ref);
+}   // async_first_n
 
 ERL_NIF_TERM
 async_close(

--- a/c_src/eleveldb.h
+++ b/c_src/eleveldb.h
@@ -52,6 +52,7 @@ ERL_NIF_TERM async_iterator_move(ErlNifEnv* env, int argc, const ERL_NIF_TERM ar
 ERL_NIF_TERM async_iterator_close(ErlNifEnv* env, int argc, const ERL_NIF_TERM argv[]);
 
 ERL_NIF_TERM async_count(ErlNifEnv* env, int argc, const ERL_NIF_TERM argv[]);
+ERL_NIF_TERM async_first_n(ErlNifEnv* env, int argc, const ERL_NIF_TERM argv[]);
 
 } // namespace eleveldb
 

--- a/c_src/workitems.h
+++ b/c_src/workitems.h
@@ -353,6 +353,26 @@ public:
 
 };  // class CountTask
 
+/**
+ * Background object for async first_n,
+ */
+
+class FirstNTask : public WorkTask
+{
+protected:
+    unsigned long _number_of_recs;
+
+public:
+    FirstNTask(ErlNifEnv *_caller_env,
+            ERL_NIF_TERM _caller_ref,
+            DbObjectPtr_t & _db_handle,
+            unsigned long _number_of_recs);
+
+    virtual ~FirstNTask();
+
+    virtual work_result DoWork();
+
+};  // class FirstNTask
 
 
 } // namespace eleveldb


### PR DESCRIPTION
Fix for https://github.com/leo-project/leofs/issues/994#issuecomment-367934356.
As described on https://github.com/leo-project/eleveldb/pull/1#issuecomment-360395610 at the previous PR, all tests should pass other than `bucket_expiry: set_verify_prop`. so the test result looks like below
```erlang
=======================================================
  Failed: 1.  Skipped: 0.  Passed: 29.
ERROR: One or more eunit tests failed.
```
Once this PR get merged, I will send PR for leo_backend_db and subsequently leo_mq.
After those 3 PR get merged and confirmed that the CPU usage get reduced, https://github.com/leo-project/leofs/issues/994 and https://github.com/leo-project/leofs/issues/710 will be able to close.